### PR TITLE
add the feature looking up symbols in the workspace.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,11 +6,12 @@ import Gtags from './global/gtags';
 import Configuration from './configuration';
 import AutoUpdateHandler from './autoUpdateHandler';
 import ShowVersionHandler from './showVersionHandler';
-import RebuildGtagsHandler from './rebuildGtagsHandler'
-import DefinitionProvider from './definitionProvider'
-import ReferenceProvider from './referenceProvider'
-import CompletionItemProvider from './completionItemProvider'
-import DocumentSymbolProvider from './documentSymbolProvider'
+import RebuildGtagsHandler from './rebuildGtagsHandler';
+import DefinitionProvider from './definitionProvider';
+import ReferenceProvider from './referenceProvider';
+import CompletionItemProvider from './completionItemProvider';
+import DocumentSymbolProvider from './documentSymbolProvider';
+import WorkspaceSymbolProvider from './workspaceSymbolProvider';
 
 const configuration = new Configuration();
 
@@ -38,6 +39,7 @@ export function activate(context: vscode.ExtensionContext) {
                      new CompletionItemProvider(global, configuration)));
     disposables.push(vscode.languages.registerDocumentSymbolProvider(['cpp', 'c'],
                      new DocumentSymbolProvider(global)));
+    disposables.push(vscode.languages.registerWorkspaceSymbolProvider(new WorkspaceSymbolProvider(global)));
 
     disposables.push(vscode.commands.registerCommand('extension.showGlobalVersion',
                      showVersionHandler.showGlobalVersion, showVersionHandler));

--- a/src/global/executableBase.ts
+++ b/src/global/executableBase.ts
@@ -1,8 +1,10 @@
-import Configuration from '../configuration'
+import Configuration from '../configuration';
 import * as iconv from 'iconv-lite';
 import Logger from '../logger';
 
 const spawnSync = require('child_process').spawnSync;
+const util = require('util');
+const exec = util.promisify(require('child_process').exec);
 
 export default abstract class ExecutableBase {
     configuration: Configuration;
@@ -26,16 +28,42 @@ export default abstract class ExecutableBase {
             encoding: 'binary'
         };
 
+        console.log(this.executable + " " + args.join(' ') + "\n");
+
         let sync = spawnSync(this.executable, args, options);
         if (sync.error) {
             throw sync.error;
-        } else if (0 != sync.status) {
+        } else if (0 !== sync.status) {
             throw sync.stderr.toString();
         }
 
         Logger.info(this.executable + " " + args + "\n" + sync.stdout);
+        console.log(sync.stdout);
 
         const encoding = this.configuration.encoding.get();
         return iconv.decode(Buffer.from(sync.stdout, 'binary'), encoding).split(/\r?\n/);
+    }
+
+    protected async execute_async(args: string[],
+        cwd: string|undefined = undefined,
+        env: any = {}
+        ) : Promise<string[]>
+    {
+        // TODO: This is a workaround for Issue#14. Remove it if vscode fixes it.
+        env.VSCODEGNUGLOBAL = 1;
+        const options = {
+            cwd: cwd,
+            env: env,
+            encoding: 'binary',
+            maxBuffer: 2*1024*1024
+        };
+
+        const {stdout, stderr} = await exec(this.executable + ' ' + args.join(' '), options);
+        if (stderr) {
+            console.log("stderr: " + stderr);
+        }
+
+        const encoding = this.configuration.encoding.get();
+        return iconv.decode(Buffer.from(stdout, 'binary'), encoding).split(/\r?\n/);
     }
 }

--- a/src/workspaceSymbolProvider.ts
+++ b/src/workspaceSymbolProvider.ts
@@ -1,0 +1,24 @@
+import * as vscode from 'vscode';
+import Global from './global/global';
+import Logger from './logger';
+
+export default class GlobalWorkspaceSymbolProvider implements vscode.WorkspaceSymbolProvider {
+    global: Global;
+
+    constructor(global: Global) {
+        this.global = global;
+    }
+
+    public async provideWorkspaceSymbols(query: string, token: vscode.CancellationToken): Promise<vscode.SymbolInformation[]> {
+        let self = this;
+        return new Promise<vscode.SymbolInformation[]>((resolve, reject) => {
+            try {
+                resolve(self.global.provideWorkspaceSymbols(query));
+            } catch (e) {
+                Logger.error("provideDocumentSymbols failed: " + e);
+                return reject(e);
+            }
+        });
+    }
+
+}


### PR DESCRIPTION
This commit uses “head” to limit the “global” results to no more than 300 lines. If not, it could not get the results. Don't know the root cause yet, and in Windows it may lacks of “head”.