### PR TITLE
[Feature] add simple fuzzy for searching workspace symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ This extension is forked/rewriten from [C/C++ Intellisense](https://marketplace.
 * `gnuGlobal.gtagsExecutable`
     * Specify the path to the gtags. Default is 'gtags'.
 
+* `gnuGlobal.gtagsLimitCommand`
+    * Specify the command pipe into Global tag search result to limit the maximum line count.
+    * Default is: `head -300`, for Windows users may set to: `more` for CMD or `Select-Object -first 300` for PowerShell.
+
 * `gnuGlobal.objDirPrefix`
     * If objDirPrefix is set and objDirPrefix directory exists, gtags creates objDirPrefix/project_dir directory and makes tag files in it. Global will also try to search tag files in that directory.
     * This option is useful if you don't wan't to create tag files in your project directory.

--- a/package.json
+++ b/package.json
@@ -89,6 +89,14 @@
                     "scope": "machine",
                     "description": "Specify the path to the gtags."
                 },
+                "gnuGlobal.gtagsLimitCommand": {
+                    "type": [
+                        "string"
+                    ],
+                    "default": "head -300",
+                    "scope": "resource",
+                    "description": "Specify the command pipe into Global tag search result to limit the maximum line count."
+                },
                 "gnuGlobal.libraryPath": {
                     "type": [
                         "array"

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -81,6 +81,8 @@ export default class GlobalConfiguration {
 
     readonly debugMode = new WindowScopeEnumConfig('gnuGlobal.debugMode',  BoolOption, BoolDefault.Disabled);
 
+    readonly gtagsLimitCommand = new WindowScopeConfig('gnuGlobal.gtagsLimitCommand', 'head -300');
+
     /* resource scope configurations */
     readonly autoUpdate = new ResourceScopeEnumConfig('gnuGlobal.autoUpdate', BoolDefault, BoolDefault.Default);
 

--- a/src/global/global.ts
+++ b/src/global/global.ts
@@ -173,6 +173,9 @@ export default class Global extends executableBase {
                            : Promise<vscode.SymbolInformation[]> {
         const word = query.split('').join('.*') + '.*'
         let cmd: string[] = ['--encode-path', '" "', '-xa', word];
+        if (this.configuration.gtagsLimitCommand.get().length) {
+            cmd.push('|' + this.configuration.gtagsLimitCommand.get())
+        }
         let lines = await this.execute_async(cmd, vscode.workspace.rootPath, this.saved_env);
 
         return mapNoneEmpty(lines, (line) => {

--- a/src/global/global.ts
+++ b/src/global/global.ts
@@ -171,8 +171,8 @@ export default class Global extends executableBase {
 
     async provideWorkspaceSymbols(query: string)
                            : Promise<vscode.SymbolInformation[]> {
-        const word = query + '*';
-        let cmd: string[] = ['--encode-path', '" "', '-xa', word, '| head -300'];
+        const word = query.split('').join('.*') + '.*'
+        let cmd: string[] = ['--encode-path', '" "', '-xa', word];
         let lines = await this.execute_async(cmd, vscode.workspace.rootPath, this.saved_env);
 
         return mapNoneEmpty(lines, (line) => {


### PR DESCRIPTION
As title, let gtags search all possible tags to vs code GUI.

also, add config setting to fix #27, #12 when using extension in Windows.
